### PR TITLE
feat: Add support for externally-managed Pod Identity associations #minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,13 @@ For questions about this template or AWS Terraform module development:
 | <a name="input_create_cluster_secret_store"></a> [create\_cluster\_secret\_store](#input\_create\_cluster\_secret\_store) | Whether to create ClusterSecretStore resources for AWS integration. | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Whether to create the IAM role for ESO. Set to false to use an externally managed role. | `bool` | `true` | no |
 | <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | Whether to create the OIDC provider. Only used when use\_pod\_identity is false (IRSA mode). | `bool` | `false` | no |
+| <a name="input_create_pod_identity_association"></a> [create\_pod\_identity\_association](#input\_create\_pod\_identity\_association) | Whether to create the Pod Identity association. Set to false when the association is managed externally by a separate IAM module. | `bool` | `true` | no |
 | <a name="input_enable_metrics"></a> [enable\_metrics](#input\_enable\_metrics) | Whether to enable Prometheus metrics for ESO. | `bool` | `true` | no |
 | <a name="input_enable_parameter_store"></a> [enable\_parameter\_store](#input\_enable\_parameter\_store) | Whether to enable AWS Systems Manager Parameter Store integration. | `bool` | `false` | no |
 | <a name="input_enable_secrets_manager"></a> [enable\_secrets\_manager](#input\_enable\_secrets\_manager) | Whether to enable AWS Secrets Manager integration. | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., dev, test, stage, prod). | `string` | n/a | yes |
 | <a name="input_eso_version"></a> [eso\_version](#input\_eso\_version) | Version of the External Secrets Operator Helm chart to deploy. | `string` | `"0.9.11"` | no |
-| <a name="input_external_iam_role_arn"></a> [external\_iam\_role\_arn](#input\_external\_iam\_role\_arn) | ARN of an externally managed IAM role to use for ESO. Only used when create\_iam\_role is false. | `string` | `null` | no |
+| <a name="input_external_iam_role_arn"></a> [external\_iam\_role\_arn](#input\_external\_iam\_role\_arn) | ARN of an externally managed IAM role to use for ESO. Required when create\_iam\_role is false or when using externally-managed Pod Identity associations (create\_pod\_identity\_association = false). | `string` | `null` | no |
 | <a name="input_helm_timeout"></a> [helm\_timeout](#input\_helm\_timeout) | Timeout for Helm chart installation (in seconds). | `number` | `600` | no |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Additional Helm values to override ESO chart defaults. | `any` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix for all resources created by this module. | `string` | n/a | yes |
@@ -317,7 +318,7 @@ For questions about this template or AWS Terraform module development:
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | The Kubernetes namespace where ESO is deployed. |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC provider (if created for IRSA). |
 | <a name="output_parameter_store_arns"></a> [parameter\_store\_arns](#output\_parameter\_store\_arns) | List of Parameter Store ARNs that ESO can access. |
-| <a name="output_pod_identity_association_arn"></a> [pod\_identity\_association\_arn](#output\_pod\_identity\_association\_arn) | The ARN of the Pod Identity Association (if created for Pod Identity). |
+| <a name="output_pod_identity_association_arn"></a> [pod\_identity\_association\_arn](#output\_pod\_identity\_association\_arn) | The ARN of the Pod Identity Association (if created by this module). Returns null if managed externally. |
 | <a name="output_quick_start_guide"></a> [quick\_start\_guide](#output\_quick\_start\_guide) | Quick start guide for using the deployed ESO instance. |
 | <a name="output_resource_tags"></a> [resource\_tags](#output\_resource\_tags) | The tags applied to resources created by this module. |
 | <a name="output_secrets_manager_arns"></a> [secrets\_manager\_arns](#output\_secrets\_manager\_arns) | List of Secrets Manager ARNs that ESO can access. |

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_iam_role" "eso" {
         Action = "sts:AssumeRole"
         Condition = {
           ArnEquals = {
-            "aws:SourceArn" = "arn:aws:eks:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:podidentityassociation/${var.cluster_name}/*"
+            "aws:SourceArn" = "arn:aws:eks:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:podidentityassociation/${var.cluster_name}/*"
           }
         }
         } : {
@@ -154,7 +154,7 @@ resource "aws_iam_role_policy" "eso_secrets_access" {
 # ================================
 
 resource "aws_eks_pod_identity_association" "eso" {
-  count = var.use_pod_identity ? 1 : 0
+  count = var.use_pod_identity && var.create_pod_identity_association ? 1 : 0
 
   cluster_name    = var.cluster_name
   namespace       = var.namespace
@@ -296,7 +296,7 @@ resource "kubectl_manifest" "cluster_secret_store_sm" {
       provider = {
         aws = {
           service = "SecretsManager"
-          region  = var.aws_region != null ? var.aws_region : data.aws_region.current.name
+          region  = var.aws_region != null ? var.aws_region : data.aws_region.current.id
           auth = {
             jwt = {
               serviceAccountRef = {
@@ -331,7 +331,7 @@ resource "kubectl_manifest" "cluster_secret_store_ps" {
       provider = {
         aws = {
           service = "ParameterStore"
-          region  = var.aws_region != null ? var.aws_region : data.aws_region.current.name
+          region  = var.aws_region != null ? var.aws_region : data.aws_region.current.id
           auth = {
             jwt = {
               serviceAccountRef = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,8 +55,8 @@ output "oidc_provider_arn" {
 }
 
 output "pod_identity_association_arn" {
-  description = "The ARN of the Pod Identity Association (if created for Pod Identity)."
-  value       = var.use_pod_identity ? try(aws_eks_pod_identity_association.eso[0].association_arn, null) : null
+  description = "The ARN of the Pod Identity Association (if created by this module). Returns null if managed externally."
+  value       = var.use_pod_identity && var.create_pod_identity_association ? try(aws_eks_pod_identity_association.eso[0].association_arn, null) : null
 }
 
 output "authentication_mode" {
@@ -103,7 +103,7 @@ output "cluster_version" {
 
 output "aws_region" {
   description = "The AWS region where secrets will be accessed."
-  value       = var.aws_region != null ? var.aws_region : data.aws_region.current.name
+  value       = var.aws_region != null ? var.aws_region : data.aws_region.current.id
 }
 
 output "aws_account_id" {


### PR DESCRIPTION
## Overview

This PR adds support for externally-managed Pod Identity associations, enabling centralized IAM management patterns where a dedicated IAM module creates and manages Pod Identity associations with consistent organizational metadata.

## Changes

### New Variable
- **`create_pod_identity_association`**: Boolean flag (default: `true`) to control whether this module creates the Pod Identity association

### Updated Resources
- **Pod Identity Association**: Now only created when both `use_pod_identity = true` AND `create_pod_identity_association = true`
- **Validation**: Added validation requiring `external_iam_role_arn` when using externally-managed Pod Identity
- **Output**: Updated `pod_identity_association_arn` to indicate when association is managed externally
- **Bug Fix**: Corrected `aws_region.current.name` to `aws_region.current.id` for proper data source attribute reference

### Documentation
- Added comprehensive `POD_IDENTITY_EXTERNAL_MANAGEMENT.md` with:
  - Feature overview and behavior matrix
  - Usage examples for all scenarios
  - Migration guide for existing deployments
  - Validation examples and testing checklist

## Behavior Matrix

| `use_pod_identity` | `create_pod_identity_association` | Behavior |
|-------------------|-----------------------------------|----------|
| `false` | any | IRSA mode (unchanged) |
| `true` | `true` | Creates association (existing behavior) |
| `true` | `false` | Uses external association (**NEW**) |

## Backward Compatibility

✅ **Fully backward compatible** - default value of `create_pod_identity_association = true` maintains existing behavior

Existing configurations will continue to work without any changes:
- No breaking changes to existing deployments
- No changes to default behavior
- All existing examples remain valid

## Use Cases

### Use Case 1: Current Behavior (Default)
```hcl
module "eso" {
  use_pod_identity                = true
  create_pod_identity_association = true  # default
  # Module creates AND uses Pod Identity association
}
```

### Use Case 2: External IAM Management (New)
```hcl
# IAM module creates Pod Identity association
module "iam" {
  role_configs = {
    ExternalSecretsOperator = {
      create_pod_identity_association = true
      # ... with org metadata
    }
  }
}

# ESO module uses existing association
module "eso" {
  use_pod_identity                = true
  create_pod_identity_association = false  # managed externally
  external_iam_role_arn           = module.iam.roles["ExternalSecretsOperator"].arn
}
```

## Benefits

- **Centralized IAM Management**: All IAM resources tagged with organizational metadata in one place
- **Separation of Concerns**: IAM team manages identities, application teams consume them
- **Compliance**: Easier to ensure all IAM resources meet compliance requirements
- **Multi-Environment**: Same IAM roles across environments with different tags

## Testing Checklist

- [x] Verified no linter errors
- [x] Backward compatibility maintained (default behavior unchanged)
- [ ] Terraform plan with existing configurations shows no changes
- [ ] Terraform apply with `create_pod_identity_association = false` works correctly
- [ ] ESO can authenticate to AWS Secrets Manager in all modes
- [ ] CI/CD pipeline passes all checks

## Related Documentation

- [AWS EKS Pod Identity Documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
- See `POD_IDENTITY_EXTERNAL_MANAGEMENT.md` for complete feature documentation