### PR TITLE
fix: Remove auth.jwt config from ClusterSecretStore when using Pod Identity #patch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -305,18 +305,24 @@ resource "kubectl_manifest" "cluster_secret_store_sm" {
     }
     spec = {
       provider = {
-        aws = {
-          service = "SecretsManager"
-          region  = var.aws_region != null ? var.aws_region : data.aws_region.current.id
-          auth = {
-            jwt = {
-              serviceAccountRef = {
-                name      = local.service_account_name
-                namespace = var.namespace
+        aws = merge(
+          {
+            service = "SecretsManager"
+            region  = var.aws_region != null ? var.aws_region : data.aws_region.current.id
+          },
+          # Only include auth block for IRSA (not for Pod Identity)
+          # Pod Identity uses default AWS SDK credential chain without explicit auth configuration
+          var.use_pod_identity ? {} : {
+            auth = {
+              jwt = {
+                serviceAccountRef = {
+                  name      = local.service_account_name
+                  namespace = var.namespace
+                }
               }
             }
           }
-        }
+        )
       }
     }
   })
@@ -340,18 +346,24 @@ resource "kubectl_manifest" "cluster_secret_store_ps" {
     }
     spec = {
       provider = {
-        aws = {
-          service = "ParameterStore"
-          region  = var.aws_region != null ? var.aws_region : data.aws_region.current.id
-          auth = {
-            jwt = {
-              serviceAccountRef = {
-                name      = local.service_account_name
-                namespace = var.namespace
+        aws = merge(
+          {
+            service = "ParameterStore"
+            region  = var.aws_region != null ? var.aws_region : data.aws_region.current.id
+          },
+          # Only include auth block for IRSA (not for Pod Identity)
+          # Pod Identity uses default AWS SDK credential chain without explicit auth configuration
+          var.use_pod_identity ? {} : {
+            auth = {
+              jwt = {
+                serviceAccountRef = {
+                  name      = local.service_account_name
+                  namespace = var.namespace
+                }
               }
             }
           }
-        }
+        )
       }
     }
   })


### PR DESCRIPTION
## Problem
When using Pod Identity (`use_pod_identity = true`), the ClusterSecretStore was incorrectly configured with `auth.jwt.serviceAccountRef`, which is only needed for IRSA. Pod Identity should use the default AWS SDK credential chain without explicit auth configuration.

## Error Observed
```
unable to create session: an IAM role must be associated with service account external-secrets (namespace: external-secrets)
```

## Solution
Updated both ClusterSecretStore resources (Secrets Manager and Parameter Store) to conditionally include the auth block:
- **Pod Identity mode** (`use_pod_identity = true`): Auth block is omitted entirely
- **IRSA mode** (`use_pod_identity = false`): Auth block with `jwt.serviceAccountRef` is included

## Changes
- Updated `kubectl_manifest.cluster_secret_store_sm` to use `merge()` with conditional auth block
- Updated `kubectl_manifest.cluster_secret_store_ps` to use `merge()` with conditional auth block
- Added inline comments explaining the authentication logic

## Expected ClusterSecretStore (Pod Identity)
```yaml
spec:
  provider:
    aws:
      region: us-west-2
      service: SecretsManager
      # No auth block - Pod Identity uses default credential chain
```

## Expected ClusterSecretStore (IRSA)
```yaml
spec:
  provider:
    aws:
      auth:
        jwt:
          serviceAccountRef:
            name: external-secrets
            namespace: external-secrets
      region: us-west-2
      service: SecretsManager
```

## Testing
- ✅ Terraform formatting validated
- ✅ Terraform validation passed
- ✅ No linter errors

## Affected Examples
- `examples/10-advanced` - Uses Pod Identity
- `examples/20-external-role` - Uses Pod Identity

## Version
This is a bug fix, tagged with `#patch` for v1.1.3 release.

Resolves v1.1.2 Pod Identity authentication issue.